### PR TITLE
Change Configure to fix issues with constant blink

### DIFF
--- a/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
+++ b/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
@@ -134,25 +134,27 @@ def parse(String description) {
 
 def configure() {
 	log.debug "Configure called for device ${device.displayName}."
-	String hubZigbeeId = swapEndianHex(device.hub.zigbeeId)
+	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	def cmd = [
     //------IAS Zone/CIE setup------//
-    "zcl global write 0x500 0x10 0xf0 {${hubZigbeeId}}", "delay 100",
-	"send 0x${device.deviceNetworkId} 1 1", "delay 200",
+    "zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
+    "send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
     
     //------Set up binding------//
-    "zdo bind 0x${device.deviceNetworkId} 1 1 0x500 {${device.zigbeeId}} {}", "delay 200",
-    "zdo bind 0x${device.deviceNetworkId} 1 1 0x501 {${device.zigbeeId}} {}", "delay 200",
-	"zdo bind 0x${device.deviceNetworkId} 1 1 1 {${device.zigbeeId}} {}", "delay 200",
-    "zdo bind 0x${device.deviceNetworkId} 1 1 0x402 {${device.zigbeeId}} {}", "delay 200",
+    "zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x500 {${device.zigbeeId}} {}", "delay 100",
+    "send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 1000",
+    "zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x501 {${device.zigbeeId}} {}", "delay 100",
+    "send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 1000",
     
     //------Configure temperature reporting------//
-    "zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}","delay 100",
-    "send 0x${device.deviceNetworkId} 1 1", "delay 500",
+    "zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x402 {${device.zigbeeId}} {}", "delay 200",
+	"zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}", "delay 200",
+	"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
     
     //------Configure battery reporting------//
-    "zcl global send-me-a-report 1 0x20 0x20 3600 21600 {01}", "delay 100",
-	"send 0x${device.deviceNetworkId} 1 1", "delay 500",
+    "zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 1 {${device.zigbeeId}} {}", "delay 200",
+	"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}", "delay 200",		//checkin time 6 hrs
+	"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 	]
     
     return cmd + refresh()


### PR DESCRIPTION
Change configure method on centralite keypads to more closely match SmartThings official DTH for centralite sensors (Used motion sensor as the base).

Fixes configure issues (constant blink) on Iris keypad (tested personally)
